### PR TITLE
Fix Crash On Cancel Payment

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -27,7 +27,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/ui/src/main/java/mz/co/moovi/mpesalibui/payment/PaymentViewModel.kt
+++ b/ui/src/main/java/mz/co/moovi/mpesalibui/payment/PaymentViewModel.kt
@@ -32,7 +32,7 @@ class PaymentViewModel(private val mpesaService: MpesaService) : ViewModel() {
 
     private lateinit var amount: String
     private var phoneNumber: String = ""
-    private lateinit var disposable: Disposable
+    private var disposable: Disposable? = null
     private lateinit var serviceProviderName: String
     private lateinit var serviceProviderCode: String
     private lateinit var thirdPartyReference: String
@@ -157,7 +157,7 @@ class PaymentViewModel(private val mpesaService: MpesaService) : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
-        disposable.dispose()
+        disposable?.dispose()
     }
 
 }

--- a/ui/src/main/res/layout/activity_payment.xml
+++ b/ui/src/main/res/layout/activity_payment.xml
@@ -5,6 +5,4 @@
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".payment.PaymentActivity">
-
-</FrameLayout>
+    tools:context=".payment.PaymentActivity"/>


### PR DESCRIPTION
Fix the crash cancelling the payment ui. This happens because when the activity is reclaimed, the PaymentViewModel onCleared is called and because no payment request was made the disposable was  not initialized and therfore the crash.