### PR TITLE
Prevent SDK from crashing

### DIFF
--- a/app/src/main/java/mz/co/moovi/mpesaapi/MainActivity.kt
+++ b/app/src/main/java/mz/co/moovi/mpesaapi/MainActivity.kt
@@ -15,7 +15,7 @@ class MainActivity : AppCompatActivity() {
         ///Initialize with application once
         MpesaSdk.init(
                 apiKey = "your_api_key_here",
-                publicKey = """your_api_key_here""",
+                publicKey = """your_public_key_here""",
                 endpointUrl = "your_endpoint_url_here",
                 serviceProviderName = "your_service_name_here",
                 serviceProviderCode = "your_service_provide_code_here",

--- a/ui/src/main/java/mz/co/moovi/mpesalibui/payment/PaymentViewModel.kt
+++ b/ui/src/main/java/mz/co/moovi/mpesalibui/payment/PaymentViewModel.kt
@@ -136,7 +136,12 @@ class PaymentViewModel(private val mpesaService: MpesaService) : ViewModel() {
                 is HttpException -> {
                     val json = throwable.response().errorBody()?.string()
                     val gsonResponse = Gson().fromJson(json, PaymentResponse::class.java)
-                    val errorMessageId = gsonResponse.output_ResponseCode.errorMessageResourceId()
+                    val outputResponse = gsonResponse.output_ResponseCode
+                    val errorMessageId = if (outputResponse != null) {
+                        outputResponse.errorMessageResourceId()
+                    } else {
+                        R.string.payment_response_ins_unhandled_response
+                    }
                     postErrorCardViewState(errorMessageId)
                 }
                 is UnknownHostException -> {


### PR DESCRIPTION
This will prevent the SDK from crashing if unexpected errors occur
while performing the payment.
Such cases could be a problem with the public or the api key.