### PR TITLE
Add reference regeneration after failure

### DIFF
--- a/ui/src/main/java/mz/co/moovi/mpesalibui/payment/PaymentViewModel.kt
+++ b/ui/src/main/java/mz/co/moovi/mpesalibui/payment/PaymentViewModel.kt
@@ -16,6 +16,7 @@ import mz.co.moovi.mpesalibui.payment.error.PaymentErrorCardViewState
 import mz.co.moovi.mpesalibui.ui.Action
 import mz.co.moovi.mpesalibui.ui.ViewAction
 import mz.co.moovi.mpesalibui.ui.ViewState
+import mz.co.moovi.mpesalibui.utils.ReferenceGenerator
 import retrofit2.HttpException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
@@ -151,6 +152,8 @@ class PaymentViewModel(private val mpesaService: MpesaService) : ViewModel() {
                     postErrorCardViewState(R.string.payment_response_ins_9)
                 }
             }
+            
+            thirdPartyReference = ReferenceGenerator.generateReference(transactionReference)
         }
     }
 


### PR DESCRIPTION
This will add a way to regenerate a new third party reference after
the failure of the payment.
The third party needs to be generated because the Mpesa API requires a
different third party reference per transaction.