### PR TITLE
add support for 84 and 85 number

### DIFF
--- a/ui/src/main/java/mz/co/moovi/mpesalibui/payment/PaymentViewModel.kt
+++ b/ui/src/main/java/mz/co/moovi/mpesalibui/payment/PaymentViewModel.kt
@@ -100,11 +100,11 @@ class PaymentViewModel(private val mpesaService: MpesaService) : ViewModel() {
     }
 
     private fun hasValidPhoneNumber(): Boolean {
-        return !phoneNumber.isEmpty() && phoneNumber.length == 7
+        return !phoneNumber.isEmpty() && phoneNumber.length == 9
     }
 
     private fun onMakePayment() {
-        val viewState = PaymentAuthenticationCardViewState(phoneNumber = "(+258) 84$phoneNumber")
+        val viewState = PaymentAuthenticationCardViewState(phoneNumber = "(+258)$phoneNumber")
         _viewState.postValue(PaymentViewState(authenticationCard = viewState))
 
         val paymentRequest = createPaymentRequest()

--- a/ui/src/main/res/layout/view_payment_card.xml
+++ b/ui/src/main/res/layout/view_payment_card.xml
@@ -80,7 +80,7 @@
             android:textAppearance="@style/TextAppearance.AppCompat.Title"
             app:layout_constraintStart_toStartOf="@+id/phone_number_label"
             app:layout_constraintTop_toBottomOf="@+id/phone_number_label"
-            tools:text="+258 84" />
+            tools:text="+258 " />
 
         <EditText
             android:id="@+id/phone_number"
@@ -88,7 +88,7 @@
             android:layout_height="wrap_content"
             android:hint="@string/payment_card_phone_number_hint"
             android:inputType="phone"
-            android:maxLength="7"
+            android:maxLength="9"
             android:textAppearance="@style/TextAppearance.AppCompat.Title"
             app:layout_constraintBaseline_toBaselineOf="@+id/phone_number_prefix"
             app:layout_constraintStart_toEndOf="@+id/phone_number_prefix" />

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <!-- Make payment card -->
     <string name="payment_card_currency" translatable="false">Mt</string>
     <string name="payment_card_phone_number_hint" translatable="false">0001002</string>
-    <string name="payment_card_phone_number_prefix" translatable="false">+258 84</string>
+    <string name="payment_card_phone_number_prefix" translatable="false">+258 </string>
     <string name="payment_card_pay_button_text">Pay with M-pesa</string>
     <string name="payment_card_view_phone_number_prompt">Insert your M-Pesa account phone number</string>
 


### PR DESCRIPTION
This will make it possible to add an 84 or 85 number.
With this change, the payment card has the country code hardcoded and allows the user to add a valida mozambican vodacom number.