### PR TITLE
Updated Glide to version 4.9.0 to fix crash when using version 4.8.0

### DIFF
--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
-    implementation 'com.github.bumptech.glide:glide:4.8.0'
+    implementation 'com.github.bumptech.glide:glide:4.9.0'
     implementation 'com.android.support:cardview-v7:28.1.1'
     implementation 'android.arch.lifecycle:extensions:1.1.1'
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
@@ -46,7 +46,7 @@ dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.8.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'android.arch.core:core-testing:1.1.1'


### PR DESCRIPTION
Hi, I was having this an error because of Glide. In my project I was using 4.9.0 while in this sdk 4.8.0 is being used so, this sdk was causing my app to crash. To solve this, a simple update of the glide version in the sdk was needed.